### PR TITLE
Make submodule path work relative to any Github repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/ehri-nn"]
 	path = themes/ehri-nn
-	url = ../ehri-nn-hugo-theme.git
+	url = ../../EHRI/ehri-nn-hugo-theme.git


### PR DESCRIPTION
This should mean people can fork the repo and deploy it without changing the path. However, there may be surprises in store...